### PR TITLE
Generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "getrandom"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ name = "rand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -147,7 +147,7 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasi"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
@@ -220,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
-"checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
+"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
@@ -237,4 +237,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
+"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"

--- a/grav_tree.h
+++ b/grav_tree.h
@@ -6,14 +6,14 @@
  * them around according to the gravity they exert on each other.
  */
 typedef struct Entity {
-  double vx;
-  double vy;
-  double vz;
-  double x;
-  double y;
-  double z;
-  double radius;
-  double mass;
+  float vx;
+  float vy;
+  float vz;
+  float x;
+  float y;
+  float z;
+  float radius;
+  float mass;
 } Entity;
 
 void *from_data_file(const char *file_path_buff);

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -27,8 +27,8 @@ pub struct Entity {
 }
 
 impl AsEntity for Entity {
-    fn as_entity(&self) -> Entity {
-        return self.clone();
+    fn as_entity(&self) -> &Entity {
+        return self;
     }
     /// Returns a new entity after gravity from a node has been applied to it.
     /// Should be read as "apply gravity from node"

--- a/src/gravtree.rs
+++ b/src/gravtree.rs
@@ -136,7 +136,7 @@ impl <T: AsEntity + Clone + Default>GravTree<T> {
     /// This is compatible with SwiftVis visualizations.
     pub fn write_data_file(self, file_path: String) {
         let mut file = File::create(file_path).unwrap(); //TODO unwraps are bad
-        let mut to_write: Vec<Entity> = self.as_vec().iter().map(|x| x.as_entity()).collect();
+        let mut to_write: Vec<Entity> = self.as_vec().iter().map(|x| x.as_entity().clone()).collect();
         let mut to_write_string: String;
         to_write_string = to_write.pop().expect("").as_string().to_string();
         while !to_write.is_empty() {
@@ -147,8 +147,8 @@ impl <T: AsEntity + Clone + Default>GravTree<T> {
             );
         }
         to_write_string = format!("{}\n", to_write_string);
-        assert!(
-            file.write(to_write_string.as_bytes()).unwrap() == to_write_string.as_bytes().len()
+        assert_eq!(
+            file.write(to_write_string.as_bytes()).unwrap(), to_write_string.as_bytes().len()
         );
     }
 }

--- a/src/gravtree.rs
+++ b/src/gravtree.rs
@@ -11,7 +11,7 @@ pub struct GravTree<T: AsEntity + Clone + Default> {
     number_of_entities: usize, // The number of entities in the tree.
 }
 
-impl <T: AsEntity + Clone + Default>GravTree<T> {
+impl <T: AsEntity + Clone + Default + Send + Sync>GravTree<T> {
     pub fn new(pts: &mut Vec<T>) -> GravTree<T> where T: AsEntity {
         let size_of_vec = pts.len();
         GravTree {
@@ -59,7 +59,7 @@ impl <T: AsEntity + Clone + Default>GravTree<T> {
         GravTree::<T>::new(
             &mut post_gravity_entity_vec
        //TODO make this a par iter later         .par_iter()
-                .iter()
+                .par_iter()
                 .map(|x| x.apply_gravity_from(&self.root))
                 .collect(),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn new(array: *const Entity, length: c_int) -> *mut c_void
 
 #[no_mangle]
 pub unsafe extern "C" fn time_step(gravtree_buf: *mut c_void) -> *mut c_void {
-    let gravtree: Box<GravTree> = Box::from_raw(gravtree_buf as *mut GravTree);
+    let gravtree: Box<GravTree<Entity>> = Box::from_raw(gravtree_buf as *mut GravTree<Entity>);
     // A seg fault happens in the below line.
     Box::into_raw(Box::new(gravtree.time_step())) as *mut c_void
 }
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn time_step(gravtree_buf: *mut c_void) -> *mut c_void {
 pub unsafe extern "C" fn from_data_file(file_path_buff: *const c_char) -> *mut c_void {
     let file_path = CStr::from_ptr(file_path_buff);
 
-    let gravtree = GravTree::from_data_file(String::from(file_path.to_str().unwrap())).unwrap();
+    let gravtree = GravTree::<Entity>::from_data_file(String::from(file_path.to_str().unwrap())).unwrap();
     Box::into_raw(Box::new(gravtree)) as *mut c_void
 }
 
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn write_data_file(
     file_path_buff: *const c_char,
     gravtree_buf: *mut c_uchar,
 ) {
-    let gravtree: GravTree = transmute_copy(&gravtree_buf);
+    let gravtree: GravTree<Entity> = transmute_copy(&gravtree_buf);
     let file_path = CStr::from_ptr(file_path_buff);
     gravtree.write_data_file(String::from(file_path.to_str().unwrap()));
 }
@@ -146,7 +146,7 @@ fn test_tree() {
 /// This function is used for testing. It checks the number of nodes on each side, along the "edge" of the tree.
 /// left_nodes is how many nodes you expect to see along the left size, and right_nodes is how many you expect to
 ///  see along the right.
-fn go_to_edges(grav_tree: GravTree, left_nodes: usize, right_nodes: usize) {
+fn go_to_edges(grav_tree: GravTree<Entity>, left_nodes: usize, right_nodes: usize) {
     let mut count_of_nodes = 0;
     let mut node = grav_tree.root.left.expect("null root node\n");
     let mut node2 = node.clone();

--- a/src/node.rs
+++ b/src/node.rs
@@ -23,6 +23,11 @@ pub struct Node<T: AsEntity + Clone + Default > {
     z_max: f64,
 }
 
+/// The trait that enables a struct to be used inside of this structure.
+/// It must be able to represent itself as an entity, i.e. provide positional and size information about itself,
+/// and it must be able to calculate gravity upon itself given another entity some distance away. In the future,
+/// I'd like to do that actual calculation in the tree and change this trait to just require that an entity
+/// can add some acceleration vector to itself.
 pub trait AsEntity {
     fn as_entity(&self) -> &Entity;
     fn apply_gravity_from<T: AsEntity + Clone + Default>(&self, node: &Node<T> ) -> Self;

--- a/src/node.rs
+++ b/src/node.rs
@@ -24,7 +24,7 @@ pub struct Node<T: AsEntity + Clone + Default > {
 }
 
 pub trait AsEntity {
-    fn as_entity(&self) -> Entity;
+    fn as_entity(&self) -> &Entity;
     fn apply_gravity_from<T: AsEntity + Clone + Default>(&self, node: &Node<T> ) -> Self;
 
 }
@@ -118,8 +118,8 @@ impl <T: AsEntity + Clone + Default> Node<T> {
     pub fn new_root_node(pts: &mut [T]) -> Node<T> {
         // Start and end are probably 0 and pts.len(), respectively.
         let length_of_points = pts.len() as i32;
-        let mut entities = pts.iter().map(|x| x.as_entity()).collect::<Vec<Entity>>();
-        let (xdistance, ydistance, zdistance) = xyz_distances(&entities);
+        let mut entities = pts.iter().map(|x| x.as_entity()).collect::<Vec<&Entity>>();
+        let (xdistance, ydistance, zdistance) = xyz_distances(entities.as_slice());
         // If our current collection is small enough to become a leaf (it has less than MAX_PTS points)
         if length_of_points <= MAX_PTS {
             // then we convert it into a leaf node.

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,5 +1,6 @@
 use super::Dimension;
 use crate::entity::Entity;
+#[allow(unused_imports)]
 use node::AsEntity;
 use std::cmp::Ordering;
 /// Returns the absolute distance in every dimension (the range in every dimension)

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,9 +1,10 @@
 use super::Dimension;
 use crate::entity::Entity;
+use node::AsEntity;
 use std::cmp::Ordering;
 /// Returns the absolute distance in every dimension (the range in every dimension)
 /// of an array slice of entities.
-pub fn xyz_distances(entities: &[Entity]) -> (f64, f64, f64) {
+pub fn xyz_distances(entities: &[&Entity]) -> (f64, f64, f64) {
     let (x_max, x_min, y_max, y_min, z_max, z_min) = max_min_xyz(entities);
     let x_distance = x_max - x_min;
     let y_distance = y_max - y_min;
@@ -13,7 +14,7 @@ pub fn xyz_distances(entities: &[Entity]) -> (f64, f64, f64) {
 
 /// Given an array slice of entities, returns the maximum and minimum x, y, and z values as
 /// a septuple.
-pub fn max_min_xyz(entities: &[Entity]) -> (&f64, &f64, &f64, &f64, &f64, &f64) {
+pub fn max_min_xyz<'a>(entities: &[&'a Entity]) -> (&'a f64, &'a f64, &'a f64, &'a f64, &'a f64, &'a f64) {
     let (x_max, x_min) = max_min(Dimension::X, entities);
     let (y_max, y_min) = max_min(Dimension::Y, entities);
     let (z_max, z_min) = max_min(Dimension::Z, entities);
@@ -26,12 +27,14 @@ fn bench_max_min(b: &mut test::Bencher) {
     for _ in 0..1000 {
         test_vec.push(Entity::random_entity());
     }
+
+    let ref_vec = test_vec.iter().map(|x| x.as_entity()).collect::<Vec<&Entity>>();
     // TODO make it do this with different vecs
-    b.iter(|| max_min_xyz(&test_vec));
+    b.iter(|| max_min_xyz(ref_vec.as_slice()));
 }
 
 /// Returns the maximum and minimum z values in a slice of entities.
-pub fn max_min(dim: Dimension, entities: &[Entity]) -> (&f64, &f64) {
+pub fn max_min<'a>(dim: Dimension, entities: &[&'a Entity]) -> (&'a f64, &'a f64) {
     (
         &entities
             .iter()
@@ -56,17 +59,17 @@ pub fn max_min(dim: Dimension, entities: &[Entity]) -> (&f64, &f64) {
 
 /// Finds the median value for a given dimension in a slice of entities.
 /// Making one that clones/uses immutability could be an interesting performance benchmark.
-pub fn find_median(dim: Dimension, pts: &mut [Entity]) -> (&f64, usize) {
+pub fn find_median<'a>(dim: Dimension, pts: &mut [&'a Entity]) -> (&'a f64, usize) {
     find_median_helper(dim, pts, 0, pts.len(), pts.len() / 2usize)
 }
 
-fn find_median_helper(
+fn find_median_helper<'a>(
     dim: Dimension,
-    pts: &mut [Entity],
+    pts: &mut [&'a Entity],
     start: usize,
     end: usize,
     mid: usize,
-) -> (&f64, usize) {
+) -> (&'a f64, usize) {
     let mut low = (start + 1) as usize;
     let mut high = (end - 1) as usize; //exclusive end
     while low <= high {


### PR DESCRIPTION
Now, the tree uses a trait-based approach to allow a struct to opt-in to the tree. There are still some improvements that need to be made:

* Do I need to require _so many_ traits (`T: AsEntity + Clone + Default + Send + Sync`)?
* Can I minimize the `AsEntity` trait to only require the entity be able to apply acceleration to itself? That way, the actual gravitational calculations can be contained within the tree, minimizing coding effort to impl that trait.